### PR TITLE
🪲 Bug fix: Compatibility with Hestia 0.0.19 fixed

### DIFF
--- a/autopeptideml/autopeptideml.py
+++ b/autopeptideml/autopeptideml.py
@@ -473,7 +473,7 @@ class AutoPeptideML:
 
         df = df.sample(len(df), random_state=self.seed).reset_index(drop=True)
 
-        train_idx, test_idx = ccpart(
+        train_idx, test_idx, label_ids = ccpart(
             df=df,
             similarity_metric=alignment,
             field_name='sequence',

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
     name='autopeptideml',
     packages=find_packages(exclude=['examples']),
     url='https://ibm.github.io/AutoPeptideML/',
-    version='1.0.0',
+    version='1.0.1',
     zip_safe=False,
 )


### PR DESCRIPTION
Hestia 0.0.19 (commit f9adc7382a893f20a80ce5074492e11757bd023c) introduced the additional output of cluster membership for each of the members of the partition. This behaviour caused a compatibility issue that we fix here.